### PR TITLE
kas/configschema.py: fix multiconfig

### DIFF
--- a/kas/configschema.py
+++ b/kas/configschema.py
@@ -97,6 +97,19 @@ CONFIGSCHEMA = {
                 },
             ],
         },
+        'multiconfig': {
+            'oneOf': [
+                {
+                    'type': 'string',
+                },
+                {
+                    'type': 'array',
+                    'items': {
+                        'type': 'string',
+                    },
+                },
+            ],
+        },
         'task': {
             'type': 'string',
         },


### PR DESCRIPTION
The `multconfig:*` syntax was not supported in the schema. #7

Signed-off-by: Tim Orling <timothy.t.orling@linux.intel.com>  