### PR TITLE
Dockerfile: add ping and ps for testimage

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,7 +17,8 @@ RUN apt-get install --no-install-recommends -y \
                        syslinux tree python3-pip bc python3-yaml \
                        lsb-release python3-setuptools ssh-client \
                        vim less mercurial iproute2 xz-utils gnupg \
-                       tmux libncurses-dev python3-wheel git-lfs && \
+                       tmux libncurses-dev python3-wheel git-lfs \
+                       iputils-ping procps && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 


### PR DESCRIPTION
HOSTTOOLS requires ping and ps when running testimage
apt-get install iputils-ping and procps to satisfy the
requirements

Signed-off-by: Tim Orling <timothy.t.orling@linux.intel.com>