### PR TITLE
Making kas-docker work with podman as docker engine

### DIFF
--- a/kas-docker
+++ b/kas-docker
@@ -106,12 +106,19 @@ while [ $# -gt 0 ]; do
 	case "$1" in
 	--isar)
 		DOCKER_IMAGE="$(echo "${DOCKER_IMAGE}" | sed 's|kasproject/kas|kasproject/kas-isar|g')"
-		ISAR_ARGS="--cap-add=SYS_ADMIN --cap-add=MKNOD --privileged"
+		ISAR_ARGS="--privileged"
 
-		# sudo is needed for a privileged podman container
-		if [ "${KAS_DOCKER_ENGINE}" = "podman" ]; then
+		case "${KAS_DOCKER_ENGINE}" in
+		docker)
+			ISAR_ARGS="${ISAR_ARGS} --cap-add=SYS_ADMIN"
+			ISAR_ARGS="${ISAR_ARGS} --cap-add=MKNOD"
+			;;
+		podman)
+			# sudo is needed for a privileged podman container
 			DOCKER_COMMAND="sudo ${DOCKER_COMMAND}"
-		fi
+			;;
+		esac
+
 		shift 1
 		;;
 	--with-loop-dev)

--- a/kas-docker
+++ b/kas-docker
@@ -116,6 +116,7 @@ while [ $# -gt 0 ]; do
 		podman)
 			# sudo is needed for a privileged podman container
 			DOCKER_COMMAND="sudo ${DOCKER_COMMAND}"
+			ISAR_ARGS="${ISAR_ARGS} --pid=host"
 			;;
 		esac
 

--- a/kas-docker
+++ b/kas-docker
@@ -93,6 +93,7 @@ docker)
 podman)
 	DOCKER_COMMAND="podman"
 	DOCKER_IMAGE="docker://${DOCKER_IMAGE}"
+	ENGINE_ARGS="--userns=keep-id --security-opt label=disable"
 	;;
 *)
 	echo "$0: unknown docker engine '${KAS_DOCKER_ENGINE}'" >&2
@@ -136,7 +137,7 @@ while [ $# -gt 0 ]; do
 		;;
 	--docker-args)
 		[ $# -gt 0 ] || usage
-		USER_ARGS=$2
+		ENGINE_ARGS="${ENGINE_ARGS} $2"
 		shift 2
 		;;
 	--ssh-dir)
@@ -317,6 +318,6 @@ if [ -z "${NO_PROXY_FROM_ENV+x}" ]; then
 	done
 fi
 
-trace ${DOCKER_COMMAND} run "$@" ${ISAR_ARGS} ${WITH_LOOP_DEV} ${USER_ARGS} \
+trace ${DOCKER_COMMAND} run "$@" ${ISAR_ARGS} ${WITH_LOOP_DEV} ${ENGINE_ARGS} \
 		 ${DOCKER_IMAGE} ${CMD} ${KAS_OPTIONS} ${KAS_FILES} \
 		 ${KAS_EXTRA_BITBAKE_ARGS}


### PR DESCRIPTION
This MR takes care of running kas-docker with podman as docker eninge.

The following kas layers have been build successfully:
- siemens/meta-iot2000 (non-isar build)
- siemens/meta-iot2050 (isar build)

All tests were run on Fedora 32 using podman 2.0.1

Please look at commit messages for more detailed information / addressed problems.