### PR TITLE
Add support for cloning private repos via SSH

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -56,3 +56,5 @@ docs/_build/
 venv/
 ENV/
 
+# IDEs
+/.idea

--- a/kas/config.py
+++ b/kas/config.py
@@ -169,3 +169,9 @@ class Config:
             if target.startswith('multiconfig:') or target.startswith('mc:'):
                 multiconfigs.append(target.split(':')[1])
         return ' '.join(multiconfigs)
+
+    def get_ssh_shortnames(self):
+        """
+            Returns a dictionary of shortnames and their host/keyfile/etc.
+        """
+        return self._config.get('ssh-config', {})

--- a/kas/configschema.py
+++ b/kas/configschema.py
@@ -124,6 +124,25 @@ CONFIGSCHEMA = {
         'task': {
             'type': 'string',
         },
+        'ssh-config': {
+            'type': 'object',
+            'additionalProperties': {
+                'type': 'object',
+                'additionalProperties': False,
+                'required': ['hostname', 'keyfile'],
+                'properties': {
+                    'hostname': {
+                        'type': 'string'
+                    },
+                    'keyfile': {
+                        'type': 'string'
+                    },
+                    'user': {
+                        'type': 'string'
+                    }
+                }
+            }
+        },
         'repos': {
             'type': 'object',
             'additionalProperties': {
@@ -146,6 +165,9 @@ CONFIGSCHEMA = {
                             },
                             'path': {
                                 'type': 'string',
+                            },
+                            'ssh-key': {
+                                'type': 'string'
                             },
                             'layers': {
                                 'type': 'object',

--- a/kas/libcmds.py
+++ b/kas/libcmds.py
@@ -132,6 +132,19 @@ class SetupHome(Command):
                       '\temail = kas@example.com\n'
                       '\tname = Kas User\n')
 
+        sshdir = os.path.join(self.tmpdirname, '.ssh')
+        if not os.path.exists(sshdir):
+            os.mkdir(sshdir)
+        with open(os.path.join(sshdir, 'config'), 'w') as f:
+            for shortname, data in ctx.config.get_ssh_shortnames().items():
+                keyfile = os.path.join(os.path.abspath(data["keyfile"]))
+                logging.info(f'Adding SSH keyfile {keyfile} with shortname {shortname}')
+                f.write(f'Host {shortname} {data["hostname"]}\n')
+                f.write(f'    HostName {data["hostname"]}\n')
+                f.write(f'    IdentityFile {keyfile}\n')
+                if data["user"] is not None:
+                    f.write(f'    User {data["user"]}\n')
+
         if os.environ.get('AWS_CONFIG_FILE', False) \
                 and os.environ.get('AWS_SHARED_CREDENTIALS_FILE', False):
             os.makedirs(self.tmpdirname + "/.aws")


### PR DESCRIPTION
In the case where layers (and bitbake dependencies of layers) need to be
cloned from private repos, it is necessary to use more than a single SSH
key (in our case, one for each repo).

This change does two things.
1) A new optional property "ssh-key" can be set on each repo in the
   config file, which is a path that points to a private key file. Git
   repos will then be able to use that private key to clone from the
   respective repository by setting GIT_SSH_COMMAND. I have not found
   any easier way to do this unfortunately.
2) In order for bitbake to be able to clone from private repos, kas now
   also writes a .ssh/config file in the temporary new home directory
   using the new section "ssh-config" in the kas config file.