### PR TITLE
repos: remove trailing slash from layer path

### DIFF
--- a/kas/repos.py
+++ b/kas/repos.py
@@ -52,7 +52,7 @@ class Repo:
 
     def __getattr__(self, item):
         if item == 'layers':
-            return [os.path.join(self.path, layer) for layer in self._layers]
+            return [os.path.join(self.path, layer).rstrip(os.sep) for layer in self._layers]
         elif item == 'qualified_name':
             url = urlparse(self.url)
             return ('{url.netloc}{url.path}'


### PR DESCRIPTION
In order for oe-core to correctly display the layers and revisions used in a build, the paths used in conf/bblayers.conf must have no trailing path separator.

More precisely, oe-core uses the following [code](https://github.com/kraj/poky/blob/dunfell/meta/classes/base.bbclass#L185) to display the list of layers, branches and commits used:

```
meta                 = "dunfell:44ab5a84770bfe28a1b52678abb58b166231dfc6"
meta-networking      
meta-oe              
meta-perl            
meta-python          = "dunfell:144077083457ccb75700777d5e6b1da9aaff01aa"
meta-poky            = "dunfell:44ab5a84770bfe28a1b52678abb58b166231dfc6"
meta-raspberrypi     = "dunfell:93305f7c3a9c338a3d2daef61514f61b4256f979"
```

It expects no trailing slash at the end of the layer's path (as read from `conf/bblayers.conf`), as having a trailing slash makes the `os.path.basename` returns the empty string.

Proof:
```
ubuntu@ubuntu:/var/data/yocto-builds$ python3
Python 3.8.2 (default, Jul 16 2020, 14:00:26) 
[GCC 9.3.0] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> import os.path
>>> print( os.path.basename('/var/data/yocto-builds/poky/meta/'))

>>> print( os.path.basename('/var/data/yocto-builds/poky/meta'))
meta
>>> 
```

In my case, using kas 2.2, while using the following yaml config, it was generating a `conf/bblayers.conf` file containing trailing slashes:

YAML:
```yaml
header:
  version: 9
machine: raspberrypi4-64
distro: poky
target:
  - core-image-minimal
repos:
  poky:
    url: https://git.yoctoproject.org/git/poky
    refspec: dunfell
    layers:
      meta:
      meta-poky:
  meta-openembedded:
    url: http://git.openembedded.org/meta-openembedded
    refspec: dunfell
    path: poky/meta-openembedded
    layers:
      meta-oe:
      meta-python:
      meta-networking:
      meta-perl:
  meta-raspberrypi:
    url: https://github.com/agherzan/meta-raspberrypi/
    path: poky/meta-raspberrypi
    refspec: dunfell
bblayers_conf_header:
  standard: |
    POKY_BBLAYERS_CONF_VERSION = "2"
    BBPATH = "${TOPDIR}"
    BBFILES ?= ""
local_conf_header:
  standard: |
    CONF_VERSION = "1"
    PACKAGE_CLASSES = "package_rpm"
    SDKMACHINE = "x86_64"
    USER_CLASSES = "buildstats image-mklibs image-prelink"
    PATCHRESOLVE = "noop"
  debug-tweaks: |
    EXTRA_IMAGE_FEATURES = "debug-tweaks ssh-server-dropbear package-management"
  diskmon: |
    BB_DISKMON_DIRS = "\
        STOPTASKS,${TMPDIR},1G,100K \
        STOPTASKS,${DL_DIR},1G,100K \
        STOPTASKS,${SSTATE_DIR},1G,100K \
        STOPTASKS,/tmp,100M,100K \
        ABORT,${TMPDIR},100M,1K \
        ABORT,${DL_DIR},100M,1K \
        ABORT,${SSTATE_DIR},100M,1K \
        ABORT,/tmp,10M,1K"
  local-mirror: |
    DL_DIR = "/var/data/downloads"
    BB_GENERATE_MIRROR_TARBALLS = "1"
  packages: |
    PREFERRED_VERSION_linux-raspberrypi = "5.4.%"
```

bblayers.conf:

```python
# standard
POKY_BBLAYERS_CONF_VERSION = "2"
BBPATH = "${TOPDIR}"
BBFILES ?= ""

BBLAYERS ?= " \
    /var/data/yocto-builds/poky/meta \
    /var/data/yocto-builds/poky/meta-openembedded/meta-networking \
    /var/data/yocto-builds/poky/meta-openembedded/meta-oe \
    /var/data/yocto-builds/poky/meta-openembedded/meta-perl \
    /var/data/yocto-builds/poky/meta-openembedded/meta-python \
    /var/data/yocto-builds/poky/meta-poky \
    /var/data/yocto-builds/poky/meta-raspberrypi/"
```

When attempting to use bitbake, the meta-raspberrypi layer name is not displayed in the logs, but its hash appears.

```
ubuntu@ubuntu:/var/data/yocto-builds/build$ bitbake vim
Parsing recipes: 100% |###############################################################################################| Time: 0:06:02
Parsing of 2192 .bb files complete (0 cached, 2192 parsed). 3339 targets, 128 skipped, 0 masked, 0 errors.
NOTE: Resolving any missing task queue dependencies

Build Configuration:
BB_VERSION           = "1.46.0"
BUILD_SYS            = "aarch64-linux"
NATIVELSBSTRING      = "universal"
TARGET_SYS           = "aarch64-poky-linux"
MACHINE              = "raspberrypi4-64"
DISTRO               = "poky"
DISTRO_VERSION       = "3.1.3"
TUNE_FEATURES        = "aarch64 cortexa72 crc crypto"
TARGET_FPU           = ""
meta                 = "dunfell:44ab5a84770bfe28a1b52678abb58b166231dfc6"
meta-networking      
meta-oe              
meta-perl            
meta-python          = "dunfell:144077083457ccb75700777d5e6b1da9aaff01aa"
meta-poky            = "dunfell:44ab5a84770bfe28a1b52678abb58b166231dfc6"
                     = "dunfell:93305f7c3a9c338a3d2daef61514f61b4256f979"
```

After applying the attached fix, the `conf/bblayers.conf` is generated without any trailing slash in the layer's path:

```python
# standard
POKY_BBLAYERS_CONF_VERSION = "2"
BBPATH = "${TOPDIR}"
BBFILES ?= ""

BBLAYERS ?= " \
    /var/data/yocto-builds/poky/meta \
    /var/data/yocto-builds/poky/meta-openembedded/meta-networking \
    /var/data/yocto-builds/poky/meta-openembedded/meta-oe \
    /var/data/yocto-builds/poky/meta-openembedded/meta-perl \
    /var/data/yocto-builds/poky/meta-openembedded/meta-python \
    /var/data/yocto-builds/poky/meta-poky \
    /var/data/yocto-builds/poky/meta-raspberrypi"
```

Also, bitbake renders the list of layers correctly

```
ubuntu@ubuntu:/var/data/yocto-builds/build$ bitbake vim
Parsing recipes: 100% |###############################################################################################| Time: 0:06:02
Parsing of 2192 .bb files complete (0 cached, 2192 parsed). 3339 targets, 128 skipped, 0 masked, 0 errors.
NOTE: Resolving any missing task queue dependencies

Build Configuration:
BB_VERSION           = "1.46.0"
BUILD_SYS            = "aarch64-linux"
NATIVELSBSTRING      = "universal"
TARGET_SYS           = "aarch64-poky-linux"
MACHINE              = "raspberrypi4-64"
DISTRO               = "poky"
DISTRO_VERSION       = "3.1.3"
TUNE_FEATURES        = "aarch64 cortexa72 crc crypto"
TARGET_FPU           = ""
meta                 = "dunfell:44ab5a84770bfe28a1b52678abb58b166231dfc6"
meta-networking      
meta-oe              
meta-perl            
meta-python          = "dunfell:144077083457ccb75700777d5e6b1da9aaff01aa"
meta-poky            = "dunfell:44ab5a84770bfe28a1b52678abb58b166231dfc6"
meta-raspberrypi     = "dunfell:93305f7c3a9c338a3d2daef61514f61b4256f979"
```