### PR TITLE
Introduce KAS_BUILD_DIR environment variable

### DIFF
--- a/docs/command-line.rst
+++ b/docs/command-line.rst
@@ -15,6 +15,8 @@ Environment variables
 +=======================+=====================================================+
 | ``KAS_WORK_DIR``      | The path of the kas work directory, current work    |
 |                       | directory is the default.                           |
+| ``KAS_BUILD_DIR``     | The path build directory, ``${KAS_WORK_DIR}/build`` |
+|                       | is the default.                                     |
 +-----------------------+-----------------------------------------------------+
 | ``KAS_REPO_REF_DIR``  | The path to the repository reference directory.     |
 |                       | Repositories in this directory are used as          |

--- a/kas-container
+++ b/kas-container
@@ -92,6 +92,12 @@ else
 	KAS_WORK_DIR="$(pwd)"
 fi
 
+if [ -n "${KAS_BUILD_DIR}" ]; then
+	KAS_BUILD_DIR=$(readlink -f "${KAS_BUILD_DIR}")
+else
+	KAS_BUILD_DIR="${KAS_WORK_DIR}/build"
+fi
+
 KAS_CONTAINER_ENGINE="${KAS_CONTAINER_ENGINE:-${KAS_DOCKER_ENGINE}}"
 if [ -z "${KAS_CONTAINER_ENGINE}" ]; then
 	# Try to auto-detect a container engine
@@ -178,17 +184,16 @@ while [ $# -gt 0 ]; do
 		;;
 	clean)
 		[ $# -eq 1 ] || usage
-		KAS_CLEAN_DIR=build/tmp
 		if [ -n "${KAS_ISAR_ARGS}" ]; then
 			set_container_image_var
 			# SC2086: Double quote to prevent globbing and word splitting.
 			# shellcheck disable=2086
-			trace ${KAS_CONTAINER_COMMAND} run -v "${KAS_WORK_DIR}":/work:rw \
-					 --workdir=/work --rm ${KAS_ISAR_ARGS} \
+			trace ${KAS_CONTAINER_COMMAND} run -v "${KAS_BUILD_DIR}":/build:rw \
+					 --workdir=/build --rm ${KAS_ISAR_ARGS} \
 					 ${KAS_CONTAINER_IMAGE} \
-					 sudo rm -rf ${KAS_CLEAN_DIR}
+					 sudo rm -rf tmp
 		else
-			trace rm -rf "${KAS_WORK_DIR}/${KAS_CLEAN_DIR}"
+			trace rm -rf "${KAS_BUILD_DIR}/tmp"
 		fi
 		exit 0
 		;;
@@ -271,6 +276,7 @@ KAS_REPO_DIR=$(git -C "${KAS_FILE_DIR}" rev-parse --show-toplevel 2>/dev/null) \
 KAS_FILES=/repo/"$(echo "${KAS_FILES}" | sed 's|'"${KAS_REPO_DIR}"'/||g;s|:|:/repo/|g')"
 
 trace mkdir -p "${KAS_WORK_DIR}"
+trace mkdir -p "${KAS_BUILD_DIR}"
 
 if [ "$(id -u)" -eq 0 ] && [ "${KAS_ALLOW_ROOT}" != "yes" ] ; then
 	echo "Error: Running as root - may break certain recipes."
@@ -281,6 +287,8 @@ fi
 
 set -- "$@" -v "${KAS_REPO_DIR}":/repo:ro \
 	-v "${KAS_WORK_DIR}":/work:rw --workdir=/work \
+	-v "${KAS_BUILD_DIR}":/build:rw \
+	-e KAS_BUILD_DIR=/build \
 	-e USER_ID="$(id -u)" -e GROUP_ID="$(id -g)" --rm
 
 if [ -n "${KAS_SSH_DIR}" ] ; then

--- a/kas/context.py
+++ b/kas/context.py
@@ -72,6 +72,9 @@ class Context:
     """
     def __init__(self, args):
         self.__kas_work_dir = os.environ.get('KAS_WORK_DIR', os.getcwd())
+        self.__kas_build_dir = os.environ.get('KAS_BUILD_DIR',
+                                              os.path.join(self.__kas_work_dir,
+                                                           'build'))
         self.__kas_repo_ref_dir = os.environ.get('KAS_REPO_REF_DIR', None)
         self.setup_initial_environ()
         self.config = None
@@ -110,7 +113,7 @@ class Context:
         """
             The path to the build directory
         """
-        return os.path.join(self.__kas_work_dir, 'build')
+        return self.__kas_build_dir
 
     @property
     def kas_work_dir(self):

--- a/tests/test_environment_variables.py
+++ b/tests/test_environment_variables.py
@@ -1,0 +1,30 @@
+import os
+import shutil
+from kas import kas
+
+
+def test_build_dir_is_placed_inside_work_dir_by_default(changedir, tmpdir):
+    conf_dir = str(tmpdir.mkdir('test_env_variables'))
+    shutil.rmtree(conf_dir, ignore_errors=True)
+    shutil.copytree('tests/test_environment_variables', conf_dir)
+
+    os.chdir(conf_dir)
+
+    kas.kas(['checkout', 'test.yml'])
+
+    assert(os.path.exists(os.path.join(os.getcwd(), 'build', 'conf')))
+
+
+def test_build_dir_can_be_specified_by_environment_variable(changedir, tmpdir):
+    conf_dir = str(tmpdir.mkdir('test_env_variables'))
+    build_dir = str(tmpdir.mkdir('test_build_dir'))
+    shutil.rmtree(conf_dir, ignore_errors=True)
+    shutil.copytree('tests/test_environment_variables', conf_dir)
+    shutil.rmtree(build_dir, ignore_errors=True)
+    os.chdir(conf_dir)
+
+    os.environ['KAS_BUILD_DIR'] = build_dir
+    kas.kas(['checkout', 'test.yml'])
+    del os.environ['KAS_BUILD_DIR']
+
+    assert(os.path.exists(os.path.join(build_dir, 'conf')))

--- a/tests/test_environment_variables/oe-init-build-env
+++ b/tests/test_environment_variables/oe-init-build-env
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+true

--- a/tests/test_environment_variables/test.yml
+++ b/tests/test_environment_variables/test.yml
@@ -1,0 +1,5 @@
+header:
+  version: 10
+
+repos:
+  this:


### PR DESCRIPTION
This variable can override default build path `${KAS_WORK_DIR}/build`.

More complex build systems may require rather large build directory to be put elsewhere. Or just to have different sort of order with metadata and build artifacts.

E.g. our CI/CD in GitLab has rather limitied space where the runner clones and starts pipelines. We put Yocto build directory to a different path, where we have the space.

Please review potential fix for already closed #40.