### PR TITLE
Apply patches before doing an environment setup

### DIFF
--- a/kas/libcmds.py
+++ b/kas/libcmds.py
@@ -57,9 +57,9 @@ class Macro:
                 InitSetupRepos(),
                 repo_loop,
                 FinishSetupRepos(),
-                SetupEnviron(),
                 SetupHome(),
                 ReposApplyPatches(),
+                SetupEnviron(),
                 WriteBBConfig(),
             ]
         else:


### PR DESCRIPTION
We may need to patch the environment setup, too.

A project I am working on for a specific reason can *not* (for now) update to a newer Yocto release. There's a problem with Python2 and current GNU/Linux distros. We need to apply a tiny patch for the internals there. This needs to happen before `SetupEnviron()`.

Thanks.