### PR TITLE
Checkout repositories using git credentials

### DIFF
--- a/kas/libcmds.py
+++ b/kas/libcmds.py
@@ -55,10 +55,10 @@ class Macro:
                 self.setup_commands.append(SetupSSHAgent())
 
             self.setup_commands += [
+                SetupHome(),
                 InitSetupRepos(),
                 repo_loop,
                 FinishSetupRepos(),
-                SetupHome(),
                 ReposApplyPatches(),
                 SetupEnviron(),
                 WriteBBConfig(),


### PR DESCRIPTION
Using ssh to authenticate against repositories to check out is enabled.
When switching to https and authentication via the git credential helper 
it is necessary to first setup the home directory before checking out the 
repositories.