### PR TITLE
Install g++-multilib in kas container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,6 +19,7 @@ RUN apt-get install --no-install-recommends -y \
         python3-setuptools python3-wheel python3-yaml python3-distro python3-jsonschema \
         gosu lsb-release file vim less procps tree tar bzip2 zstd bc tmux libncurses-dev \
         dosfstools mtools parted lz4 \
+        g++-multilib \
         git-lfs/buster-backports mercurial iproute2 ssh-client curl rsync gnupg awscli sudo && \
     if [ "$TARGETPLATFORM" = "linux/amd64" ]; then \
         apt-get install --no-install-recommends -y gcc-multilib syslinux; \


### PR DESCRIPTION
Some recipes, especially meta-qt5 packages, requires g++-multilib in
the host as stated in a few projects issues [1] [2].

[1] https://github.com/siemens/meta-iot2000/issues/18#issuecomment-293417336
[2] https://github.com/meta-qt5/meta-qt5/issues/348#issuecomment-677154661

Install the package in the kas container.