### PR TITLE
kas-container: add tmpfs option for podman

### DIFF
--- a/kas-container
+++ b/kas-container
@@ -125,7 +125,7 @@ docker)
 	;;
 podman)
 	KAS_CONTAINER_COMMAND="podman"
-	KAS_RUNTIME_ARGS="--userns=keep-id --security-opt label=disable"
+	KAS_RUNTIME_ARGS="--tmpfs /tmp --userns=keep-id --security-opt label=disable"
 	;;
 *)
 	echo "$0: unknown container engine '${KAS_CONTAINER_ENGINE}'" >&2


### PR DESCRIPTION
Trying to build a simple nodistro qemux86 core-image-base image with
kas-container using podman on any branch after zeus fails.

build host: openSUSE 15.3
container: podman (specifically 2.1.1 on openSUSE 15.3)
branches: dunfell, gatesgarth, hardknott, honister, master
config.yml:
	header:
		version: 11
	machine: qemux86
	distro: nodistro
	target:
		- core-image-base
	repos:
		bitbake:
			path: layers/bitbake
			layers:
				conf: disabled
		openembedded-core:
			path: layers/openembedded-core
			layers:
				meta:

Although I'm using openSUSE 15.3 and podman 2.1.1 specifically, others have
reported similar issues with other hosts and versions of podman. Every such
build fails at some point due to pseudo erroring out. Builds on warrior and
zeus with the exact same setup succeed. The underlying reasons why this patch
fixes pseudo issues post-zeus are not known.

This patch's trick of adding "--tmpfs /tmp" to podman's arguments was
suggested by Quentin Schulz.

Signed-off-by: Quentin Schulz <foss+yocto@0leil.net>
Signed-off-by: Trevor Woerner <twoerner@gmail.com>