### PR TITLE
config: Fix include file handling if no config file is given

### DIFF
--- a/kas/config.py
+++ b/kas/config.py
@@ -41,23 +41,22 @@ class Config:
         self._override_target = target
         self._override_task = task
         self._config = {}
-        if filename:
-            self.filenames = [os.path.abspath(configfile)
-                              for configfile in filename.split(':')]
-            self.top_repo_path = Repo.get_root_path(
-                os.path.dirname(self.filenames[0]))
+        if not filename:
+            filename = os.path.join(ctx.kas_work_dir, CONFIG_YAML_FILE)
 
-            repo_paths = [Repo.get_root_path(os.path.dirname(configfile),
-                                             fallback=False)
-                          for configfile in self.filenames]
+        self.filenames = [os.path.abspath(configfile)
+                          for configfile in filename.split(':')]
+        self.top_repo_path = Repo.get_root_path(
+            os.path.dirname(self.filenames[0]))
 
-            if len(set(repo_paths)) > 1:
-                raise IncludeException('All concatenated config files must '
-                                       'belong to the same repository or all '
-                                       'must be outside of versioning control')
-        else:
-            self.filenames = [os.path.join(ctx.kas_work_dir, CONFIG_YAML_FILE)]
-            self.top_repo_path = os.getcwd()
+        repo_paths = [Repo.get_root_path(os.path.dirname(configfile),
+                                         fallback=False)
+                      for configfile in self.filenames]
+
+        if len(set(repo_paths)) > 1:
+            raise IncludeException('All concatenated config files must '
+                                   'belong to the same repository or all '
+                                   'must be outside of versioning control')
 
         self.handler = IncludeHandler(self.filenames, self.top_repo_path)
         self.repo_dict = self._get_repo_dict()

--- a/kas/libkas.py
+++ b/kas/libkas.py
@@ -378,9 +378,8 @@ def ssh_no_host_key_check():
 
 def setup_parser_common_args(parser):
     parser.add_argument('config',
-                        help='Config file, using .config.yaml if none is '
-                        'specified and using the current directory as '
-                        'repository anchor',
+                        help='Config file, using .config.yaml in KAS_WORK_DIR '
+                        'if none is specified',
                         nargs='?')
     parser.add_argument('--skip',
                         help='Skip build steps',


### PR DESCRIPTION
If we do not specify a configuration file, the repository anchor is
set to the current working directory, which breaks the resolution of
repo-/file-relative include file paths in the IncludeHandler class.

Signed-off-by: Johann Neuhauser <jneuhauser@dh-electronics.com>