### PR TITLE
Feature: tracking remote branch with refspec

### DIFF
--- a/kas/repos.py
+++ b/kas/repos.py
@@ -370,6 +370,15 @@ class GitRepo(RepoImpl):
         Provides the git functionality for a Repo.
     """
 
+    def __init__(self, name, url, path, refspec, layers, patches,
+                 disable_operations):
+        self.tracking = None
+        tracking_delimiter = '@'
+        if refspec and tracking_delimiter in refspec:
+            self.tracking, refspec = refspec.split(tracking_delimiter)
+        super().__init__(name, url, path, refspec, layers, patches,
+                 disable_operations)
+
     def remove_ref_prefix(self, refspec):
         ref_prefix = 'refs/'
         return refspec[refspec.startswith(ref_prefix) and len(ref_prefix):]
@@ -416,6 +425,8 @@ class GitRepo(RepoImpl):
         cmd = ['git', 'checkout', '-q', self.remove_ref_prefix(desired_ref)]
         if branch:
             cmd.extend(['-B', self.remove_ref_prefix(self.refspec)])
+        elif self.tracking:
+            cmd.extend(['-B', self.remove_ref_prefix(self.tracking)])
         if get_context().force_checkout:
             cmd.append('--force')
         return cmd

--- a/tests/test_refspec.py
+++ b/tests/test_refspec.py
@@ -100,3 +100,23 @@ def test_url_no_refspec(changedir, tmpdir):
     os.chdir(tdir)
     with pytest.raises(SystemExit):
         kas.kas(['shell', 'test4.yml', '-c', 'true'])
+
+
+def test_tracking_refspec(changedir, tmpdir):
+    """
+        Test branch with a pinned commit.
+    """
+    tdir = str(tmpdir.mkdir('test_tracking_refspec'))
+    shutil.rmtree(tdir, ignore_errors=True)
+    shutil.copytree('tests/test_refspec', tdir)
+    os.chdir(tdir)
+
+    kas.kas(['shell', 'test5.yml', '-c', 'true'])
+    (rc, output) = run_cmd(['git', 'symbolic-ref', '-q', 'HEAD'], cwd='kas',
+                           fail=False, liveupdate=False)
+    assert rc == 0
+    assert output.strip() == 'refs/heads/master'
+    (rc, output) = run_cmd(['git', 'rev-parse', 'HEAD'], cwd='kas',
+                           fail=False, liveupdate=False)
+    assert rc == 0
+    assert output.strip() == '907816a5c4094b59a36aec12226e71c461c05b77'

--- a/tests/test_refspec/test5.yml
+++ b/tests/test_refspec/test5.yml
@@ -1,0 +1,9 @@
+header:
+  version: 8
+
+repos:
+  this:
+
+  kas:
+    url: https://github.com/siemens/kas.git
+    refspec: master@907816a5c4094b59a36aec12226e71c461c05b77


### PR DESCRIPTION
Disclaimer: I had to submit this patch on GitHub, because our company SMTP server mangles the messages.

This feature allows checking out a specific commit of a meta-layer while still tracking remote branches (see [mailing-list](https://groups.google.com/g/kas-devel/c/v72L23oFXHg) for more info).
It is only a proof-of-concept and probably not ready to merge.