### PR TITLE
Fixes for nixos and other system where dependencies not install system wide

### DIFF
--- a/kas/context.py
+++ b/kas/context.py
@@ -111,6 +111,17 @@ class Context:
             if val:
                 self.environ[key] = val
 
+        import shutil
+        dep_cmds = ['git', 'hg']
+        path_for_deps = ':'.join(sorted({
+            os.path.dirname(cmd_path) for cmd_path in (
+                shutil.which(cmd) for cmd in dep_cmds
+            )
+            if cmd_path is not None})
+        )
+        if path_for_deps:
+            self.environ['PATH'] = path_for_deps
+
     @property
     def build_dir(self):
         """

--- a/kas/context.py
+++ b/kas/context.py
@@ -95,7 +95,7 @@ class Context:
                                 'LANG': 'en_US.utf8',
                                 'LANGUAGE': 'en_US'}
                 break
-            elif distro_base in ['debian', 'ubuntu', 'gentoo']:
+            elif distro_base in ['debian', 'ubuntu', 'gentoo', 'nixos']:
                 self.environ = {'LC_ALL': 'en_US.UTF-8',
                                 'LANG': 'en_US.UTF-8',
                                 'LANGUAGE': 'en_US:en'}


### PR DESCRIPTION
Allow this tool to run on nixos systems and fixes issue when `git` is not installed system wide on other systems.
