### PR TITLE
Dockerfile: run entrypoint as root

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -112,4 +112,4 @@ RUN apt-get update && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
-USER builder
+USER root


### PR DESCRIPTION
Hi!

From the commit message:

```
Since 492b2c56abfc, the entrypoint is executed as 'builder' user. 
Therefore, using a USER_ID and GROUP_ID currently fails: 
groupmod: Permission denied.
groupmod: cannot lock /etc/group; try again later. 
usermod: group '1000' does not exist
chown: changing ownership of '/builder/.bash_logout': Operation not permitted
chown: changing ownership of '/builder/.profile': Operation not permitted
chown: changing ownership of '/builder/.bashrc': Operation not permitted
chown: changing ownership of '/builder': Operation not permitted
error: failed switching to "builder": operation not permitted

As the entrypoint is designed to be executed as root, revert it back.
```

Reproducible with: `docker run --rm -it -e "USER_ID=1000" -e "GROUP_ID=1000" ghcr.io/siemens/kas/kas:4.0`
Debuggable with:
```
docker run --rm -it --entrypoint bash ghcr.io/siemens/kas/kas:4.0
builder@49a8a8928466:/$ USER_ID=1000 GROUP_ID=1000 /kas/container-entrypoint
```