### PR TITLE
repos: Add KAS_GIT_SHALLOW to implement git shallow clone/fetch

### DIFF
--- a/docs/command-line.rst
+++ b/docs/command-line.rst
@@ -46,6 +46,12 @@ Environment variables
 |                          | space-separated, its replacement. E.g.:          |
 |                          | "http://.*\.someurl\.io/ http://localmirror.net/"|
 +--------------------------+--------------------------------------------------+
+| ``KAS_GIT_SHALLOW``      | Perform shallow git clone/fetch using --depth=N  |
+|                          | specified by this variable. This is useful in    |
+|                          | case CI always starts with empty work directory  |
+|                          | and this directory is always discarded after the |
+|                          | CI run.                                          |
++--------------------------+--------------------------------------------------+
 | ``SSH_PRIVATE_KEY``      | Variable containing the private key that should  |
 |                          | be added to an internal ssh-agent. This key      |
 |                          | cannot be password protected. This setting is    |

--- a/kas/repos.py
+++ b/kas/repos.py
@@ -478,6 +478,11 @@ class GitRepo(RepoImpl):
 
     def clone_cmd(self, srcdir, createref):
         cmd = ['git', 'clone', '-q']
+
+        depth = os.environ.get('KAS_GIT_SHALLOW')
+        if depth:
+            cmd.extend(['--depth', depth])
+
         if createref:
             cmd.extend([self.effective_url, '--bare', srcdir])
         elif srcdir:
@@ -498,6 +503,11 @@ class GitRepo(RepoImpl):
 
     def fetch_cmd(self):
         cmd = ['git', 'fetch', '-q']
+
+        depth = os.environ.get('KAS_GIT_SHALLOW')
+        if depth:
+            cmd.extend(['--depth', depth])
+
         if self.tag:
             cmd.append('--tags')
 

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -28,6 +28,7 @@ import json
 import yaml
 import pytest
 from kas import kas
+from kas.libkas import run_cmd
 from kas.libkas import TaskExecError
 
 
@@ -81,6 +82,19 @@ def test_checkout_create_refs(changedir, tmpdir):
     del os.environ['KAS_REPO_REF_DIR']
     assert os.path.exists(str(repo_cache / 'github.com.siemens.kas.git'))
     assert os.path.exists('kas/.git/objects/info/alternates')
+
+
+def test_checkout_shallow(changedir, tmpdir):
+    tdir = str(tmpdir / 'test_commands')
+    shutil.copytree('tests/test_commands', tdir)
+    os.chdir(tdir)
+    os.environ['KAS_GIT_SHALLOW'] = '1'
+    kas.kas(['checkout', 'test-shallow.yml'])
+    del os.environ['KAS_GIT_SHALLOW']
+    (rc, output) = run_cmd(['git', 'rev-list', '--count', 'HEAD'], cwd='kas',
+                           fail=False, liveupdate=False)
+    assert rc == 0
+    assert output.strip() == '1'
 
 
 def test_repo_includes(changedir, tmpdir):

--- a/tests/test_commands/test-shallow.yml
+++ b/tests/test_commands/test-shallow.yml
@@ -1,0 +1,9 @@
+header:
+  version: 14
+
+repos:
+  this:
+
+  kas:
+    url: https://github.com/siemens/kas.git
+    commit: master


### PR DESCRIPTION
Add new environment variable KAS_GIT_SHALLOW which adds '--depth=N' to the 'git clone' and 'git fetch' commands. This forces git to perform shallow clone, which saves bandwidth and CI runner disk space. The depth 'N' is derived from KAS_GIT_SHALLOW value.

This is useful in case CI always starts with empty work directory and this directory is always discarded after the CI run. In that case, it makes no sense to clone the entire repository, instead clone just enough to reproduce the desired state of the repository and assemble the checkout of it.

This is also useful when cloning massive repositories which would otherwise take long time to clone.