### PR TITLE
Don't add comments to .netrc

### DIFF
--- a/kas/libcmds.py
+++ b/kas/libcmds.py
@@ -241,7 +241,6 @@ class SetupHome(Command):
         if os.environ.get('CI_SERVER_HOST', False) \
                 and os.environ.get('CI_JOB_TOKEN', False):
             with open(self.tmpdirname + '/.netrc', 'a') as fds:
-                fds.write('\n# appended by kas, you have gitlab CI env\n')
                 fds.write('machine ' + os.environ['CI_SERVER_HOST'] + '\n'
                           'login gitlab-ci-token\n'
                           'password ' + os.environ['CI_JOB_TOKEN'] + '\n')


### PR DESCRIPTION
A recent change to OE core causes bitbake to fallback to ~/.netrc when BB_HASHSERVE_USERNAME or BB_HASHSERVE_PASSWORD are not set.

This exposes us to an error when running in GitLab because kas has been inserting a comment into this file.

netrc.NetrcParseError: bad toplevel token 'appended'

Don't use comments in .netrc as they are not a documented feature.