### PR TITLE
fix(GitRepo): use git diff-index to check if dirty

### DIFF
--- a/kas/repos.py
+++ b/kas/repos.py
@@ -620,7 +620,7 @@ class GitRepo(RepoImpl):
         return cmd
 
     def is_dirty_cmd(self):
-        return ['git', 'status', '-s']
+        return ['git', 'diff-index', 'HEAD', '--']
 
     def resolve_branch_cmd(self):
         refspec = self.remove_ref_prefix(self.branch or self.refspec)


### PR DESCRIPTION
git status -s fails in VSCode devcontainers, when users have status.branch = true set in their global .gitconfig, as the branch name is always printed and the dirty-check checks for any stdout output.

This would not be a problem, if we could check the return code instead, but hg status will exit with zero. Otherwise, we could add the --quiet option to the git is_dirty_cmd.