### PR TITLE
Add support for credential-helper "cache" in git.

### DIFF
--- a/kas-container
+++ b/kas-container
@@ -76,6 +76,8 @@ usage()
 	printf "%b" "--aws-dir\t\tDirectory containing AWScli configuration.\n"
 	printf "%b" "--git-credential-store\tFile path to the git credential " \
 		    "store\n"
+	printf "%b" "--git-credential-socket\tPath to the git credential cache " \
+	       "socket.\n"
 	printf "%b" "--no-proxy-from-env\tDo not inherit proxy settings from " \
 		    "environment.\n"
 	printf "%b" "--repo-ro\t\tMount current repository read-only\n" \
@@ -300,6 +302,13 @@ while [ $# -gt 0 ]; do
 		KAS_GIT_CREDENTIAL_STORE="$2"
 		shift 2
 		;;
+
+	--git-credential-socket)
+		[ $# -gt 2 ] || usage
+		KAS_GIT_CREDENTIAL_SOCKET="$2"
+		shift 2
+		;;
+
 	--no-proxy-from-env)
 		KAS_NO_PROXY_FROM_ENV=1
 		shift 1
@@ -557,6 +566,15 @@ if [ -n "${KAS_GIT_CREDENTIAL_STORE}" ] ; then
 	fi
 	KAS_GIT_CREDENTIAL_HELPER_DEFAULT="store --file=/var/kas/userdata/.git-credentials"
 	set -- "$@" -v "$(readlink -fv "${KAS_GIT_CREDENTIAL_STORE}")":/var/kas/userdata/.git-credentials:ro
+fi
+
+if [ -n "${KAS_GIT_CREDENTIAL_SOCKET}" ] ; then
+	if [ ! -S "${KAS_GIT_CREDENTIAL_SOCKET}" ]; then
+		fatal_error "passed KAS_GIT_CREDENTIAL_SOCKET '${KAS_GIT_CREDENTIAL_SOCKET}' is not a socket"
+	fi
+
+	KAS_GIT_CREDENTIAL_HELPER_DEFAULT="cache --socket=/var/kas/userdata/.git-cache-socket"
+	set -- "$@" -v "$(readlink -fv "${KAS_GIT_CREDENTIAL_SOCKET}")":/var/kas/userdata/.git-cache-socket
 fi
 
 GIT_CREDENTIAL_HELPER="${GIT_CREDENTIAL_HELPER:-${KAS_GIT_CREDENTIAL_HELPER_DEFAULT}}"


### PR DESCRIPTION
This commit allows to export the git-credential-cache from the host to the kas container.

By using the git-credential-cache it is not required to pass a plaintext file with the credentials as required before by "credential store".