### PR TITLE
kas-container only supported the "store credential helper" for HTTPS-…

### DIFF
--- a/docs/userguide/credentials.rst
+++ b/docs/userguide/credentials.rst
@@ -42,6 +42,40 @@ When running in a GitHub Action or GitLab CI job, the ``.gitconfig`` file
 is automatically injected. Otherwise, the environment variable
 ``GITCONFIG_FILE`` needs to point to the `.gitconfig` kas should use.
 
+
+Git credential cache
+~~~~~~~~~~~~~~~~~~~~
+
+You can share git credentials with the kas-container by using Git credential helpers. This allows you to avoid re-entering your credentials for every Git operation.
+
+Enable credential caching on your host machine with the following command:
+
+.. code-block:: bash
+
+    git config --global credential.helper 'cache --timeout=86400'
+
+From the host, perform a Git operation that requires authentication, such as a `git pull`, in a password-protected repository:
+
+.. code-block:: bash
+
+    git pull
+
+After entering your credentials once, Git will store them and make them available through a background daemon that exposes a socket.
+
+You should see a running process similar to this on your host:
+
+.. code-block:: bash
+
+    /usr/lib/git-core/git credential-cache--daemon $HOME/.cache/git/credential/socket
+
+
+Now, you can launch the Kas container with the Git credential socket option:
+
+.. code-block:: bash
+
+  kas-container --git-credential-socket $HOME/.cache/git/credential/socket <other options...>
+
+
 GitHub Actions
 ~~~~~~~~~~~~~~
 

--- a/kas-container
+++ b/kas-container
@@ -78,6 +78,8 @@ usage()
 	printf "%b" "--aws-dir\t\tDirectory containing AWScli configuration.\n"
 	printf "%b" "--git-credential-store\tFile path to the git credential " \
 		    "store\n"
+	printf "%b" "--git-credential-socket\tPath to the git credential cache " \
+	       "socket.\n"
 	printf "%b" "--no-proxy-from-env\tDo not inherit proxy settings from " \
 		    "environment.\n"
 	printf "%b" "--repo-ro\t\tMount current repository read-only\n" \
@@ -344,6 +346,13 @@ while [ $# -gt 0 ]; do
 		KAS_GIT_CREDENTIAL_STORE="$2"
 		shift 2
 		;;
+
+	--git-credential-socket)
+		[ $# -gt 2 ] || usage
+		KAS_GIT_CREDENTIAL_SOCKET="$2"
+		shift 2
+		;;
+
 	--no-proxy-from-env)
 		KAS_NO_PROXY_FROM_ENV=1
 		shift 1
@@ -602,6 +611,14 @@ if [ -n "${KAS_GIT_CREDENTIAL_STORE}" ] ; then
 	fi
 	KAS_GIT_CREDENTIAL_HELPER_DEFAULT="store --file=/var/kas/userdata/.git-credentials"
 	set -- "$@" -v "$(realpath -e "${KAS_GIT_CREDENTIAL_STORE}")":/var/kas/userdata/.git-credentials:ro
+fi
+
+if [ -n "${KAS_GIT_CREDENTIAL_SOCKET}" ] ; then
+	if [ ! -S "${KAS_GIT_CREDENTIAL_SOCKET}" ]; then
+		fatal_error "passed KAS_GIT_CREDENTIAL_SOCKET '${KAS_GIT_CREDENTIAL_SOCKET}' is not a socket"
+	fi
+	KAS_GIT_CREDENTIAL_HELPER_DEFAULT="cache --socket=/var/kas/userdata/.git-cache-socket"
+	set -- "$@" -v "$(realpath -e "${KAS_GIT_CREDENTIAL_SOCKET}")":/var/kas/userdata/.git-cache-socket
 fi
 
 GIT_CREDENTIAL_HELPER="${GIT_CREDENTIAL_HELPER:-${KAS_GIT_CREDENTIAL_HELPER_DEFAULT}}"


### PR DESCRIPTION
…based repositories, which required storing credentials in plain

text file. This  commit adds support for the "cache credential helper", allowing credentials  to be securely stored and reused without needing repeated input.

Usage:

Enable credential caching on the host:
  git config --global credential.helper 'cache --timeout=86400'

From the host, perform a git pull (or any other operation requiring credentials) in your password-protected repository. After entering credentials once, Git will store them and make them available through a background daemon that exposes a socket.

In the host, you should see a running process similar to:
  /usr/lib/git-core/git credential-cache--daemon $HOME/.cache/git/credential/socket

Launch the Kas container with the Git credential socket option:
    kas-container --git-credential-socket $HOME/.cache/git/credential/socket <other options...>