### PR TITLE
Allow branch override

### DIFF
--- a/docs/format-changelog.rst
+++ b/docs/format-changelog.rst
@@ -193,3 +193,11 @@ Various keys for signature verification of repositories were added:
 - top level ``signers`` object to specify keys for signature verification
 - in repo definitions, ``signed`` and ``allowed_signers`` are added to
   specify whether a repo is signed and which data to use for verification.
+
+Version 20
+----------
+
+Added
+~~~~~
+
+- The repo key ``branch`` can now be overridden, including to a null-value.

--- a/kas/repos.py
+++ b/kas/repos.py
@@ -273,6 +273,7 @@ class Repo:
                                'for local repositories.')
         if refspec is None:
             commit = repo_overrides.get('commit', commit)
+            branch = repo_overrides.get('branch', branch)
             if commit and get_context().update:
                 logging.warning(f'Update of "{name}" requested, but repo is '
                                 'pinned to a fixed commit. Not updating.')

--- a/kas/schema-kas.json
+++ b/kas/schema-kas.json
@@ -26,7 +26,7 @@
                         {
                             "type": "integer",
                             "minimum": 1,
-                            "maximum": 19
+                            "maximum": 20
                         }
                     ]
                 },
@@ -118,6 +118,10 @@
                         "type": "object",
                         "additionalProperties": false,
                         "properties": {
+                            "branch": {
+                                "description": "Branch in which to find the overridden commit, can be Null",
+                                "type": ["string", "null"]
+                            },
                             "commit": {
                                 "type": "string"
                             }


### PR DESCRIPTION
Hello,

I wanted to send this patch but my company's email client makes it hard to reply to mailing lists.
I hope we can have the discussion here and I will eventually send the patch to the mailing list.

Since eb4d112 when commit and branch are specified, kas checks if the commit is actually contained in the branch.
This makes it impossible to have a branch set for a repo but use a commit override to build a merge request on this repo (obviously not yet on the specified branch).

This change allows the branch property of repos to be overridden to a specific value, or even to Null.

Let me know if the branch override should only accept the Null value. In my use case this is the only value I am interested in.

Regards,
Nicolas