### PR TITLE
kas-container: Fix podman detection

### DIFF
--- a/kas-container
+++ b/kas-container
@@ -313,7 +313,9 @@ setup_kas_dirs
 KAS_CONTAINER_ENGINE="${KAS_CONTAINER_ENGINE:-${KAS_DOCKER_ENGINE}}"
 if [ -z "${KAS_CONTAINER_ENGINE}" ]; then
 	# Try to auto-detect a container engine
-	if command -v docker >/dev/null; then
+	if command -v podman >/dev/null; then
+		KAS_CONTAINER_ENGINE=podman
+	elif command -v docker >/dev/null; then
 		case $(docker -v 2>/dev/null) in
 		podman*)
 			# The docker command is an alias for podman
@@ -327,8 +329,6 @@ if [ -z "${KAS_CONTAINER_ENGINE}" ]; then
 			# The docker command is an unknown engine
 			fatal_error "docker command found, but unknown engine detected"
 		esac
-	elif command -v podman >/dev/null; then
-		KAS_CONTAINER_ENGINE=podman
 	else
 		fatal_error "no container engine found, need docker or podman"
 	fi


### PR DESCRIPTION
When "docker -v" is ran and podman docker compatibility is enabled, podman will report the version string as "docker version x.x.x". Due to this the check will fail and report unknown engine.

<img width="1475" height="182" alt="image" src="https://github.com/user-attachments/assets/e9d9077b-a8ad-40b3-9d26-3745910431eb" />
