### PR TITLE
`cleanall` should use the DL_DIR environment variable if set

### DIFF
--- a/kas/plugins/clean.py
+++ b/kas/plugins/clean.py
@@ -158,7 +158,8 @@ class CleanAll(CleanSstate):
     def run(self, args):
         super().run(args)
         ctx = get_context()
-        downloads_dir = Path(ctx.build_dir) / 'downloads'
+        downloads_dir = Path(os.environ.get('DL_DIR',
+                                            Path(ctx.build_dir) / 'downloads'))
         if downloads_dir.exists():
             logging.info(f'Removing {downloads_dir}/*')
             if not args.dry_run:


### PR DESCRIPTION
I noticed that `kas cleanall` was not removing files in my `${HOME}/.cache/kas/downloads` directory. I provide this directory to `kas` using the `DL_DIR` environment variable.

After reviewing the `CleanAll` plugin class, the `downloads_dir` variable only uses `Path(ctx.build_dir) / 'downloads'`, instead of checking if the `DL_DIR` environment variable is set.

This PR updates the `run` function in the `CleanAll` class to check if the `DL_DIR` is set, and uses it's value as the `Path` used when performing cleanup.