### PR TITLE
publish a wheel

### DIFF
--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -41,8 +41,8 @@ git commit -m "Release $NEW_VERSION"
 git tag -s -m "Release $NEW_VERSION" "$NEW_VERSION"
 git push --follow-tags
 
-python3 -m build --sdist
-twine upload -s -r pypi "dist/kas-$NEW_VERSION.tar.gz"
+python3 -m build
+twine upload -s -r pypi "dist/{kas-$NEW_VERSION.tar.gz,kas-$NEW_VERSION-py3-none-any.whl}"
 
 authors=$(git shortlog -s "$OLD_VERSION".."$NEW_VERSION" | cut -c8- | paste -s -d, - | sed -e 's/,/, /g')
 highlights=$(sed -e "/$OLD_VERSION$/,\$d" CHANGELOG.md)


### PR DESCRIPTION
Publish a wheel, as well as a source distribution

In python, all package installation is from wheel.  So if maintainers do not publish wheels, then every user install must start by building a wheel.

That has a few minor disadvantages: it is slower, it is a thing that can go wrong, security-conscious users will want to avoid code execution at install time...

Best practice is to publish both sdist and wheel