### PR TITLE
docs: Add link to kas-container script

### DIFF
--- a/docs/userguide/kas-container-description.inc
+++ b/docs/userguide/kas-container-description.inc
@@ -1,4 +1,7 @@
 The ``kas-container`` script is a wrapper to run `kas` inside a build container.
+The script is directly available in the root of the source code repository tree,
+but can be also directly downloaded with
+`this link <https://raw.githubusercontent.com/siemens/kas/refs/heads/master/kas-container>`
 It gives fine grained control over the data that is mapped into the build and
 decouples the build environment from the host system. For details, see
 :ref:`env-vars-label`. The wrapper also takes care of mounting the necessary


### PR DESCRIPTION
A user reading the documentation might not have checked-out the repository and therefore not have the "kas-container" script yet or even not know where it can be found. This patch adds:
- a hyperlink to enable KAS usage without even cloning the repository
- information on where it can be found in the repository