### PR TITLE
context: add Arch Linux to debian/ubuntu/gentoo locale group

### DIFF
--- a/kas/context.py
+++ b/kas/context.py
@@ -114,7 +114,7 @@ class Context:
                                 'LANG': 'en_US.utf8',
                                 'LANGUAGE': 'en_US'}
                 break
-            elif distro_base in ['debian', 'ubuntu', 'gentoo']:
+            elif distro_base in ['debian', 'ubuntu', 'gentoo', 'arch']:
                 self.environ = {'LC_ALL': 'en_US.UTF-8',
                                 'LANG': 'en_US.UTF-8',
                                 'LANGUAGE': 'en_US:en'}


### PR DESCRIPTION
Arch Linux was not included in the supported distros list, causing kas to skip default locale configuration with a warning.

WARNING  - kas: No supported distros found in ['arch']. No default locales set.

Arch uses the same UTF-8 locale format as debian/ubuntu/gentoo, so add it to that group.