### PR TITLE
Add 'BB_HASHSERVE_DB_DIR' to environment variables

### DIFF
--- a/kas/libkas.py
+++ b/kas/libkas.py
@@ -494,7 +494,7 @@ def get_build_environ(build_system, ctx):
 
     conf_env = ctx.config.get_environment()
 
-    env_vars = ['SSTATE_DIR', 'SSTATE_MIRRORS', 'DL_DIR', 'TMPDIR']
+    env_vars = ['SSTATE_DIR', 'SSTATE_MIRRORS', 'DL_DIR', 'TMPDIR', 'BB_HASHSERVE_DB_DIR']
     env_vars.extend(conf_env)
 
     env.update(conf_env)


### PR DESCRIPTION
[PATCH] kas: add BB_HASHSERVE_DB_DIR to allowed environment variables

Kas allows SSTATE_DIR to be set via an environment variable, but the latest oe-core will now warn if hashequiv has been enabled[1], the sstate is outside the build tree, but the hashequiv database is inside the build tree. This is because the hashequiv data is needed to make full use of the sstate objects.

The solution here is to also set the hashserver database location, but this can't be done in the same way as SSTATE_DIR as we can't set it as an environment variable. Add BB_HASHSERVE_DB_DIR to the list of variables that can be set in the environment so that callers can set them both if needed.

* taken from that mail list https://groups.google.com/g/kas-devel/c/dPlFJ2qgpTQ