### PR TITLE
fix(kas-container): preserve quoting in --runtime-args values

### DIFF
--- a/kas-container
+++ b/kas-container
@@ -782,8 +782,14 @@ fi
 
 # SC2086: Double quote to prevent globbing and word splitting.
 # shellcheck disable=2086
-set -- "$@" ${KAS_ISAR_ARGS} ${KAS_RUNTIME_ARGS} ${KAS_EXTRA_RUNTIME_ARGS} \
-    ${KAS_CONTAINER_IMAGE} ${KAS_OPTIONS_DIRECT} ${KAS_CMD} ${KAS_OPTIONS}
+set -- "$@" ${KAS_ISAR_ARGS} ${KAS_RUNTIME_ARGS}
+# eval so that quoting inside --runtime-args values is honored, allowing
+# runtime arguments whose values contain spaces, e.g.
+#   --runtime-args "--device-cgroup-rule 'b 7:* rmw'"
+eval "set -- \"\$@\" ${KAS_EXTRA_RUNTIME_ARGS}"
+# SC2086: Double quote to prevent globbing and word splitting.
+# shellcheck disable=2086
+set -- "$@" ${KAS_CONTAINER_IMAGE} ${KAS_OPTIONS_DIRECT} ${KAS_CMD} ${KAS_OPTIONS}
 if [ -n "${KAS_BITBAKE_C_OPTION_ARGS}" ]; then
 	set -- "$@" -c "${KAS_BITBAKE_C_OPTION_ARGS}"
 fi


### PR DESCRIPTION
The accumulated --runtime-args string is expanded unquoted, so it is word-split without honoring any quoting inside it. This makes it impossible to pass runtime arguments whose values contain spaces, e.g.

```
  kas-container --runtime-args "--device-cgroup-rule 'b 7:* rmw'" ...
```

which the engine receives as the four arguments "--device-cgroup-rule", "'b", "7:*" and "rmw'".

Expand `KAS_EXTRA_RUNTIME_ARGS` through eval instead, so shell quoting inside the user-supplied string survives and such values reach the container engine intact. Space-separated flags without quoting behave as before, and repeated `--runtime-args` usage still accumulates. Only the user-supplied string is eval'd; the internal argument lists keep the plain word-splitting expansion.